### PR TITLE
Add Flask UI with login and stream viewer

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,79 @@
+from flask import Flask, render_template, request, redirect, url_for, session
+from functools import wraps
+import requests
+import os
+
+app = Flask(__name__)
+app.secret_key = os.environ.get('SECRET_KEY', 'dev_secret')
+
+# Simple in-memory user store. Replace with database or proper user management in production.
+USERS = {
+    'admin': 'password'
+}
+
+# Base URL for OME API to fetch available streams
+OME_API_URL = os.environ.get('OME_API_URL', 'http://localhost:8081/v1/stream')
+
+def login_required(f):
+    """Decorator to ensure routes require authentication."""
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        if 'username' not in session:
+            return redirect(url_for('login'))
+        return f(*args, **kwargs)
+    return decorated_function
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    """Handle user login."""
+    error = None
+    if request.method == 'POST':
+        username = request.form.get('username')
+        password = request.form.get('password')
+        if USERS.get(username) == password:
+            session['username'] = username
+            return redirect(url_for('streams'))
+        else:
+            error = 'Invalid credentials'
+    return render_template('login.html', error=error)
+
+@app.route('/logout')
+def logout():
+    """Log out the current user."""
+    session.clear()
+    return redirect(url_for('login'))
+
+def fetch_streams():
+    """Retrieve stream information from OME API."""
+    try:
+        response = requests.get(OME_API_URL, timeout=3)
+        response.raise_for_status()
+        data = response.json()
+        streams = []
+        # Expecting data either as list of streams or dict containing 'streams'
+        if isinstance(data, list):
+            for idx, item in enumerate(data):
+                streams.append({
+                    'name': item.get('name', f'stream{idx}'),
+                    'url': item.get('playUrl')
+                })
+        elif isinstance(data, dict) and 'streams' in data:
+            for item in data.get('streams', []):
+                streams.append({
+                    'name': item.get('name', item.get('id')), 
+                    'url': item.get('playUrl')
+                })
+        return streams
+    except Exception:
+        # On failure return empty list (could log error in real application)
+        return []
+
+@app.route('/streams')
+@login_required
+def streams():
+    """Display available streams using OvenPlayer."""
+    stream_list = fetch_streams()
+    return render_template('streams.html', streams=stream_list)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+requests

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}MediaCloudUI{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/ovenplayer@latest/dist/ovenplayer.js"></script>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="#">MediaCloudUI</a>
+        <div class="d-flex">
+            {% if session.get('username') %}
+                <span class="navbar-text me-3">Logged in as {{ session['username'] }}</span>
+                <a class="btn btn-outline-secondary" href="{{ url_for('logout') }}">Logout</a>
+            {% endif %}
+        </div>
+    </div>
+</nav>
+{% block content %}{% endblock %}
+</body>
+</html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% block title %}Login - MediaCloudUI{% endblock %}
+{% block content %}
+<div class="container" style="max-width: 400px;">
+    <h2 class="mb-4">Login</h2>
+    {% if error %}
+    <div class="alert alert-danger">{{ error }}</div>
+    {% endif %}
+    <form method="POST" action="{{ url_for('login') }}">
+        <div class="mb-3">
+            <label for="username" class="form-label">Username</label>
+            <input type="text" class="form-control" id="username" name="username" required>
+        </div>
+        <div class="mb-3">
+            <label for="password" class="form-label">Password</label>
+            <input type="password" class="form-control" id="password" name="password" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Login</button>
+    </form>
+</div>
+{% endblock %}

--- a/templates/streams.html
+++ b/templates/streams.html
@@ -1,0 +1,28 @@
+{% extends 'base.html' %}
+{% block title %}Streams - MediaCloudUI{% endblock %}
+{% block content %}
+<div class="container">
+    <h2 class="mb-4">Available Streams</h2>
+    <div class="row">
+        {% for stream in streams %}
+        <div class="col-md-6 mb-4">
+            <div class="card">
+                <div class="card-body">
+                    <h5 class="card-title">{{ stream.name }}</h5>
+                    <div id="player-{{ loop.index }}" style="width:100%;height:360px;"></div>
+                </div>
+            </div>
+        </div>
+        {% else %}
+        <p>No streams available.</p>
+        {% endfor %}
+    </div>
+</div>
+<script>
+{% for stream in streams %}
+OvenPlayer.create('player-{{ loop.index }}', {
+    sources: [{type: 'webrtc', file: '{{ stream.url }}'}]
+});
+{% endfor %}
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Flask application with login and session auth
- integrate OvenMediaEngine stream discovery and playback via OvenPlayer
- use Bootstrap styling with templates and requirements

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2dbeac9fc832fa54ce410998e6feb