### PR TITLE
Add OME info dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # MediaCloudUI
 cloud interface for mediaserver managment and access control
+
+## Configuration
+
+The Flask app queries Oven Media Engine's REST API. If the API is protected
+with basic authentication, set the following environment variables or rely on
+their defaults:
+
+- `OME_API_URL` (default `http://localhost:8081/v1/stream`)
+- `OME_API_USER` (default `user`)
+- `OME_API_PASS` (default `pass`)
+
+These values correspond to the `<AccessToken>` configured in OME's
+`Server.xml`.
+
+## Pages
+
+- `/streams` – lists discovered streams and plays them via OvenPlayer.
+- `/info` – shows general OME system data and per-stream publisher/subscriber
+  details.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,135 @@
+from flask import Flask, render_template, request, redirect, url_for, session
+from functools import wraps
+import requests
+import os
+
+app = Flask(__name__)
+app.secret_key = os.environ.get('SECRET_KEY', 'dev_secret')
+
+# Simple in-memory user store. Replace with database or proper user management in production.
+USERS = {
+    'admin': 'password'
+}
+
+# Base URL and credentials for OME API
+# The environment variable `OME_API_URL` should point to the stream discovery
+# endpoint (``/v1/stream``). We derive the base API path for other queries by
+# trimming the final path component.
+OME_STREAM_URL = os.environ.get('OME_API_URL', 'http://localhost:8081/v1/stream')
+OME_API_BASE = OME_STREAM_URL.rsplit('/', 1)[0]
+OME_API_USER = os.environ.get('OME_API_USER', 'user')
+OME_API_PASS = os.environ.get('OME_API_PASS', 'pass')
+
+def login_required(f):
+    """Decorator to ensure routes require authentication."""
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        if 'username' not in session:
+            return redirect(url_for('login'))
+        return f(*args, **kwargs)
+    return decorated_function
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    """Handle user login."""
+    error = None
+    if request.method == 'POST':
+        username = request.form.get('username')
+        password = request.form.get('password')
+        if USERS.get(username) == password:
+            session['username'] = username
+            return redirect(url_for('streams'))
+        else:
+            error = 'Invalid credentials'
+    return render_template('login.html', error=error)
+
+@app.route('/logout')
+def logout():
+    """Log out the current user."""
+    session.clear()
+    return redirect(url_for('login'))
+
+def fetch_streams():
+    """Retrieve stream information from OME API."""
+    try:
+        response = requests.get(OME_STREAM_URL, timeout=3, auth=(OME_API_USER, OME_API_PASS))
+        response.raise_for_status()
+        data = response.json()
+        streams = []
+        # Expecting data either as list of streams or dict containing 'streams'
+        if isinstance(data, list):
+            for idx, item in enumerate(data):
+                streams.append({
+                    'name': item.get('name', f'stream{idx}'),
+                    'url': item.get('playUrl')
+                })
+        elif isinstance(data, dict) and 'streams' in data:
+            for item in data.get('streams', []):
+                streams.append({
+                    'name': item.get('name', item.get('id')), 
+                    'url': item.get('playUrl')
+                })
+        return streams
+    except Exception:
+        # On failure return empty list (could log error in real application)
+        return []
+
+def fetch_system_info():
+    """Return general system information from OME."""
+    try:
+        response = requests.get(f"{OME_API_BASE}/system", timeout=3, auth=(OME_API_USER, OME_API_PASS))
+        response.raise_for_status()
+        return response.json()
+    except Exception:
+        return {}
+
+def fetch_stream_connections():
+    """Gather publisher (inputs) and subscriber (outputs) info grouped by stream."""
+    streams = {}
+    # Publishers / inputs
+    try:
+        resp = requests.get(f"{OME_API_BASE}/publishers", timeout=3, auth=(OME_API_USER, OME_API_PASS))
+        resp.raise_for_status()
+        data = resp.json()
+        publishers = data.get('publishers') if isinstance(data, dict) else data
+        for item in publishers or []:
+            name = item.get('streamName') or item.get('stream') or item.get('name')
+            if not name:
+                continue
+            streams.setdefault(name, {'in': [], 'out': []})
+            streams[name]['in'].append(item)
+    except Exception:
+        pass
+    # Subscribers / outputs
+    try:
+        resp = requests.get(f"{OME_API_BASE}/subscribers", timeout=3, auth=(OME_API_USER, OME_API_PASS))
+        resp.raise_for_status()
+        data = resp.json()
+        subscribers = data.get('subscribers') if isinstance(data, dict) else data
+        for item in subscribers or []:
+            name = item.get('streamName') or item.get('stream') or item.get('name')
+            if not name:
+                continue
+            streams.setdefault(name, {'in': [], 'out': []})
+            streams[name]['out'].append(item)
+    except Exception:
+        pass
+    return streams
+
+@app.route('/streams')
+@login_required
+def streams():
+    """Display available streams using OvenPlayer."""
+    stream_list = fetch_streams()
+    return render_template('streams.html', streams=stream_list)
+
+@app.route('/info')
+@login_required
+def info():
+    """Display general system information and per-stream connection details."""
+    system_info = fetch_system_info()
+    stream_info = fetch_stream_connections()
+    return render_template('info.html', system=system_info, streams=stream_info)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+requests

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}MediaCloudUI{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/ovenplayer@latest/dist/ovenplayer.js"></script>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="#">MediaCloudUI</a>
+        {% if session.get('username') %}
+        <div class="navbar-nav me-auto">
+            <a class="nav-link" href="{{ url_for('streams') }}">Streams</a>
+            <a class="nav-link" href="{{ url_for('info') }}">Info</a>
+        </div>
+        {% endif %}
+        <div class="d-flex">
+            {% if session.get('username') %}
+                <span class="navbar-text me-3">Logged in as {{ session['username'] }}</span>
+                <a class="btn btn-outline-secondary" href="{{ url_for('logout') }}">Logout</a>
+            {% endif %}
+        </div>
+    </div>
+</nav>
+{% block content %}{% endblock %}
+</body>
+</html>

--- a/templates/info.html
+++ b/templates/info.html
@@ -1,0 +1,51 @@
+{% extends 'base.html' %}
+{% block title %}Info - MediaCloudUI{% endblock %}
+{% block content %}
+<div class="container">
+    <h2 class="mb-4">General Information</h2>
+    {% if system %}
+    <table class="table table-sm">
+        <tbody>
+        {% for key, value in system.items() %}
+            <tr><th>{{ key }}</th><td>{{ value }}</td></tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    <p>No system information available.</p>
+    {% endif %}
+
+    <h2 class="mt-5 mb-4">Stream Connections</h2>
+    {% if streams %}
+        {% for name, info in streams.items() %}
+        <div class="card mb-3">
+            <div class="card-header">{{ name }}</div>
+            <div class="card-body">
+                <h5>Inputs</h5>
+                {% if info.in %}
+                    <ul class="list-unstyled">
+                    {% for item in info.in %}
+                        <li><pre>{{ item | tojson(indent=2) }}</pre></li>
+                    {% endfor %}
+                    </ul>
+                {% else %}
+                    <p class="text-muted">No inputs</p>
+                {% endif %}
+                <h5 class="mt-3">Outputs</h5>
+                {% if info.out %}
+                    <ul class="list-unstyled">
+                    {% for item in info.out %}
+                        <li><pre>{{ item | tojson(indent=2) }}</pre></li>
+                    {% endfor %}
+                    </ul>
+                {% else %}
+                    <p class="text-muted">No outputs</p>
+                {% endif %}
+            </div>
+        </div>
+        {% endfor %}
+    {% else %}
+        <p>No stream connection information available.</p>
+    {% endif %}
+</div>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% block title %}Login - MediaCloudUI{% endblock %}
+{% block content %}
+<div class="container" style="max-width: 400px;">
+    <h2 class="mb-4">Login</h2>
+    {% if error %}
+    <div class="alert alert-danger">{{ error }}</div>
+    {% endif %}
+    <form method="POST" action="{{ url_for('login') }}">
+        <div class="mb-3">
+            <label for="username" class="form-label">Username</label>
+            <input type="text" class="form-control" id="username" name="username" required>
+        </div>
+        <div class="mb-3">
+            <label for="password" class="form-label">Password</label>
+            <input type="password" class="form-control" id="password" name="password" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Login</button>
+    </form>
+</div>
+{% endblock %}

--- a/templates/streams.html
+++ b/templates/streams.html
@@ -1,0 +1,28 @@
+{% extends 'base.html' %}
+{% block title %}Streams - MediaCloudUI{% endblock %}
+{% block content %}
+<div class="container">
+    <h2 class="mb-4">Available Streams</h2>
+    <div class="row">
+        {% for stream in streams %}
+        <div class="col-md-6 mb-4">
+            <div class="card">
+                <div class="card-body">
+                    <h5 class="card-title">{{ stream.name }}</h5>
+                    <div id="player-{{ loop.index }}" style="width:100%;height:360px;"></div>
+                </div>
+            </div>
+        </div>
+        {% else %}
+        <p>No streams available.</p>
+        {% endfor %}
+    </div>
+</div>
+<script>
+{% for stream in streams %}
+OvenPlayer.create('player-{{ loop.index }}', {
+    sources: [{type: 'webrtc', file: '{{ stream.url }}'}]
+});
+{% endfor %}
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- derive base API URL for OME requests
- add info dashboard showing system stats and stream I/O details
- link new dashboard from navbar and document available pages

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2dbeac9fc832fa54ce410998e6feb