### PR TITLE
Fix OME API base path and use stats endpoints for stream info

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,21 +3,26 @@ cloud interface for mediaserver managment and access control
 
 ## Configuration
 
-The Flask app queries Oven Media Engine's REST API. If the API is protected
-with basic authentication, set the following environment variables or rely on
-their defaults:
+The Flask app queries Oven Media Engine's REST API (`/v1`). If the API is
+protected with basic authentication, set the following environment variables or
+rely on their defaults:
 
 - `OME_API_URL` (default `http://localhost:8081/v1/stream`)
 - `OME_API_USER` (default `user`)
 - `OME_API_PASS` (default `pass`)
 
 These values correspond to the `<AccessToken>` configured in OME's
-`Server.xml`.
+`Server.xml`. `OME_API_URL` should point to the stream discovery endpoint and
+the application will automatically derive the base API path (ending in `/v1/`)
+to query additional resources such as:
+
+- `/stats/current/vhosts/<vhost>/apps/<app>` – application-level statistics
+- `/stats/current/vhosts/<vhost>/apps/<app>/streams/<stream>` – per-stream statistics
+- `/vhosts/<vhost>/apps/<app>/streams` – list of available streams
 
 
 ## Pages
 
 - `/streams` – lists discovered streams and plays them via OvenPlayer.
-- `/info` – shows general OME system data and per-stream publisher/subscriber
-  details.
+- `/info` – shows application stats and per-stream metrics.
 

--- a/templates/info.html
+++ b/templates/info.html
@@ -21,26 +21,7 @@
         <div class="card mb-3">
             <div class="card-header">{{ name }}</div>
             <div class="card-body">
-                <h5>Inputs</h5>
-                {% if info.in %}
-                    <ul class="list-unstyled">
-                    {% for item in info.in %}
-                        <li><pre>{{ item | tojson(indent=2) }}</pre></li>
-                    {% endfor %}
-                    </ul>
-                {% else %}
-                    <p class="text-muted">No inputs</p>
-                {% endif %}
-                <h5 class="mt-3">Outputs</h5>
-                {% if info.out %}
-                    <ul class="list-unstyled">
-                    {% for item in info.out %}
-                        <li><pre>{{ item | tojson(indent=2) }}</pre></li>
-                    {% endfor %}
-                    </ul>
-                {% else %}
-                    <p class="text-muted">No outputs</p>
-                {% endif %}
+                <pre>{{ info | tojson(indent=2) }}</pre>
             </div>
         </div>
         {% endfor %}


### PR DESCRIPTION
## Summary
- derive API base from `OME_API_URL` with trailing slash
- use `/v1/stats/current/vhosts/default/apps/app` and per-stream endpoints for metrics
- document stats endpoints and adjust info page to show stream stats

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b30e0fe6b0832fb57799d2b31951f2